### PR TITLE
Install openssl-dev and libffi-dev required by streamparse build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN apk --update add \
     gcc \
     python \
     python-dev \
-    py-pip
+    py-pip \
+    openssl-dev \
+    libffi-dev
 
 RUN pip install -U pip
 


### PR DESCRIPTION
Latest version of streamparse requires libssl and libffi headers.